### PR TITLE
feat: use same base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM balenalib/raspberry-pi-debian-python:buster-run-20211014
 
 RUN \
     install_packages \
-        miniupnpc \
+        miniupnpc
 
 WORKDIR /opt/nebra/upnp
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Using same base image across all containers will reduce number of layers and therefore reduce image size of OS image

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Change base image across as many containers as possible to reduce image size

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/helium-miner-software/issues/182